### PR TITLE
reduce the output executable size further, from ~41KB to ~11KB, passing `-gc none` to V, and `-O3 -flto` to C

### DIFF
--- a/vroom
+++ b/vroom
@@ -65,15 +65,14 @@ C_FILE=$OUTPUT_FILE.c
 
 # Generating C file
 echo "Generating C file..."
-v $1 -skip-unused -o $C_FILE
+v $1 -skip-unused -gc none -o $C_FILE
 
 # Build it with clang
 echo "Building..."
-clang -Oz -s -w -fno-stack-protector -fno-math-errno \
+clang -O3 -flto -s -w -fno-stack-protector -fno-math-errno \
       -Wl,-z,norelro -Wl,--hash-style=gnu -fdata-sections \
       -ffunction-sections -Wl,--build-id=none -Wl,--gc-sections \
       -fno-unwind-tables -fno-asynchronous-unwind-tables \
-      -lgc \
       $C_FILE -o $OUTPUT_FILE
 
 # Echo strip the executable


### PR DESCRIPTION
With this PR:
![image](https://github.com/SheatNoisette/vroom/assets/26967/7b7d94a0-001b-4c9a-9111-4d0daf2f9e37)
